### PR TITLE
Changed object short form to long form

### DIFF
--- a/app/assets/javascripts/form-validation.js
+++ b/app/assets/javascripts/form-validation.js
@@ -389,7 +389,10 @@ function checkIfTimeFormat() {
       notTimeFormat = true;
     }
   });
-  return {inputEmpty, notTimeFormat};
+  return {
+    inputEmpty: inputEmpty,
+    notTimeFormat: notTimeFormat
+  };
 }
 
 $('#add-button').click(function(e) {


### PR DESCRIPTION
Just being aware that we don't have Babel/anything in atm to transpile back to ES5 language so removing things like object shorthand in case they don't work in a browser at user testing in the future 😄 